### PR TITLE
Fix framework search path for manual installation

### DIFF
--- a/ios/RNTaplyticsReact.xcodeproj/project.pbxproj
+++ b/ios/RNTaplyticsReact.xcodeproj/project.pbxproj
@@ -217,6 +217,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PODS_ROOT)/**",
+					"$(SRCROOT)/../../../ios/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -244,6 +245,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PODS_ROOT)/**",
+					"$(SRCROOT)/../../../ios/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
If you want to install manually (because you don’t use cocoapods) then you need the framework search path set otherwise it won’t build.