### PR TITLE
[#153124490] Update push method

### DIFF
--- a/ios/RNTaplyticsReact.m
+++ b/ios/RNTaplyticsReact.m
@@ -121,9 +121,9 @@ RCT_EXPORT_METHOD(registerPushNotifications)
     [Taplytics registerPushNotifications];
 }
 
-RCT_EXPORT_METHOD(registerPushNotificationsWithTypes:(NSInteger)types)
+RCT_EXPORT_METHOD(registerPushNotificationsWithTypes:(NSInteger)types categories:(nullable NSSet*)categories)
 {
-  [Taplytics registerPushNotificationsWithTypes:types];
+    [Taplytics registerPushNotificationsWithTypes:types categories:categories];
 }
 
 RCT_EXPORT_METHOD(registerLocationAccess)


### PR DESCRIPTION
We've removed `[Taplytics registerPushNotificationsWithTypes:types]` and replaced it with `[Taplytics registerPushNotificationsWithTypes:types categories:categories]`. 

This updates the React Native side to handle that. 

Resolves #11 