### PR TITLE
RN 0.47+ compatibility.

### DIFF
--- a/android/src/main/java/com/taplytics/react/TaplyticsReactPackage.java
+++ b/android/src/main/java/com/taplytics/react/TaplyticsReactPackage.java
@@ -17,7 +17,6 @@ public class TaplyticsReactPackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new TaplyticsReactModule(reactContext));
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
Removing `@override` annotation in `TaplyticsReactPackage.java` to make library compatible with newer versions of React Native.