### PR TITLE
Fix crashes from propertiesLoadedCallback being called multiple times

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -150,7 +150,7 @@ Taplytics.newSyncVariable("My Variable", "default").then(value => {
 IMPORTANT: The value of these variables will be determined immediately, ie. the SDK will not wait for properties to be loaded from the server. Thus, if you want to ensure that the variables have their correct variables based on your experiment segmentation, you must initialize them after the properties have been loaded from the server. This module provides a callback to achieve this:
 
 ```javascript
-Taplytics.propertiesLoadedCallback().then(() => {
+Taplytics.propertiesLoadedCallback(loaded => {
   // load variables here
 });
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare module 'taplytics-react-native' {
   namespace Taplytics {
-    export interface TaplyticsUserAttributes extends object {
+    export interface TaplyticsUserAttributes extends Object {
       email?: string;
       name?: string;
       age?: number;
@@ -53,7 +53,7 @@ declare module 'taplytics-react-native' {
      * properties have been loaded from the server. This module provides a callback to
      * achieve this:
      */
-    export function propertiesLoadedCallback(): Promise<void>;
+    export function propertiesLoadedCallback(callback: (loaded: boolean) => void): void;
 
     /**
      * Asynchronous variables take care of insuring that the experiments have been loaded

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ import _ from 'lodash';
 
 const { Taplytics } = NativeModules;
 
+Taplytics.nativeEventEmitter = new NativeEventEmitter(Taplytics);
+
 let variables = {}
 let variableChangedListener = () => {}
 
@@ -94,7 +96,6 @@ Taplytics.setTaplyticsExperimentsUpdatedListener = (listener) => {
   })
 }
 
-
 Taplytics.setTaplyticsNewSessionListener = (listener) => {
   Taplytics._setTaplyticsNewSessionListener()
 
@@ -132,9 +133,16 @@ Taplytics.registerPushReceivedListener = (listener) => {
   }
 }
 
+Taplytics.propertiesLoadedCallback = (callback) => {
+  Taplytics.nativeEventEmitter.addListener('propertiesLoadedCallback', (loaded) => {
+    callback(loaded)
+  })
+  Taplytics._propertiesLoadedCallback()
+}
+
 if (Platform.OS == 'ios') {
   try {
-    new NativeEventEmitter(Taplytics).addListener("pushOpened", (event) => {
+    Taplytics.nativeEventEmitter.addListener("pushOpened", (event) => {
       _.each(pushOpenedListeners, listener => _.isFunction(listener) && listener(event))
     }) 
   }
@@ -153,7 +161,7 @@ if (Platform.OS == 'ios') {
 
 if (Platform.OS == 'ios') {
   try {
-    new NativeEventEmitter(Taplytics).addListener("pushReceived", (event) => {
+    Taplytics.nativeEventEmitter.addListener("pushReceived", (event) => {
       _.each(pushReceivedListeners, listener => _.isFunction(listener) && listener(event))
     }) 
   } catch (err) {

--- a/ios/RNTaplyticsReact.m
+++ b/ios/RNTaplyticsReact.m
@@ -130,10 +130,10 @@ RCT_EXPORT_METHOD(runCodeBlock:(NSString *)name codeBlock:(RCTResponseSenderBloc
     }];
 }
 
-RCT_REMAP_METHOD(propertiesLoadedCallback, propertiesLoadedCallbackResolver:(RCTPromiseResolveBlock)resolve propertiesLoadedCallbackRejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(_propertiesLoadedCallback)
 {
     [Taplytics propertiesLoadedCallback:^(BOOL loaded) {
-        resolve(@(loaded));
+        [self sendEvent:@"propertiesLoadedCallback" withValue:@(loaded)];
     }];
 }
 


### PR DESCRIPTION
Crash occurs because in React Native, a native module callback can only be called once (in this case `resolve`). Instead we use an event emitter to send our data over to the JavaScript side.