### PR TITLE
Add propertiesLoadedCallback to supported events

### DIFF
--- a/ios/RNTaplyticsReact.m
+++ b/ios/RNTaplyticsReact.m
@@ -12,7 +12,7 @@
 
 - (NSArray<NSString *> *)supportedEvents
 {
-    return @[@"pushOpened",@"pushReceived"];
+    return @[@"propertiesLoadedCallback",@"pushOpened",@"pushReceived"];
 }
 
 - (void)sendEvent:(NSString *)name withValue:(id)value


### PR DESCRIPTION
Crash occurs due to listening for an event that isn't in list of supported events. 