### PR TITLE
Fix missing bridge on reload

### DIFF
--- a/ios/RNTaplyticsReact.m
+++ b/ios/RNTaplyticsReact.m
@@ -3,7 +3,14 @@
 
 @implementation RNTaplyticsReact
 
-@synthesize bridge = _bridge;
++ (id)allocWithZone:(NSZone *)zone {
+    static RNTaplyticsReact *sharedInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [super allocWithZone:zone];
+    });
+    return sharedInstance;
+}
 
 - (dispatch_queue_t)methodQueue
 {


### PR DESCRIPTION
Use a singleton pattern for our event emitter class to fix the bridge not being set on reload.

A more detailed explanation of the issue below:

```
libc++abi.dylib: terminating with uncaught exception of type NSException
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Error when sending event: propertiesLoadedCallback with body: true. Bridge is not set. This is probably because you've explicitly synthesized the bridge in RNTaplyticsReact, even though it's inherited from RCTEventEmitter.'
terminating with uncaught exception of type NSException
```