### PR TITLE
Add event emitter pattern for async variables on iOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,9 @@ Taplytics.newSyncVariable = (name, defaultValue) => {
   })
 }
 
+const asyncVarCallbackDispatcher = new Map()
+let asyncVarCallbackId = 0
+
 Taplytics.newAsyncVariable = (name, defaultValue, callback) => {
   const cb = (err, value) => {
     if (err) {
@@ -53,7 +56,13 @@ Taplytics.newAsyncVariable = (name, defaultValue, callback) => {
 
   let args = [name, defaultValue]
   if (Platform.OS === 'ios') {
-    args.push(cb)
+    Taplytics.nativeEventEmitter.addListener('asyncVariable', ({id, value}) => {
+      const cb = asyncVarCallbackDispatcher.get(id)
+      if (cb) cb(null, value)
+    })
+    args.push(asyncVarCallbackId)
+    asyncVarCallbackDispatcher.set(asyncVarCallbackId, cb)
+    asyncVarCallbackId++
   }
 
   if (_.isBoolean(defaultValue)) {

--- a/ios/RNTaplyticsReact.m
+++ b/ios/RNTaplyticsReact.m
@@ -78,28 +78,28 @@ RCT_REMAP_METHOD(_newSyncObject, name:(NSString *)name defaultValue:(NSString *)
 }
 
 
-RCT_EXPORT_METHOD(_newAsyncBool:(NSString *)name defaultValue:(BOOL)defaultValue callback:(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(_newAsyncBool:(NSString *)name defaultValue:(BOOL)defaultValue callbackId:(nonnull NSNumber *)_id)
 {
     [TaplyticsVar taplyticsVarWithName:name defaultValue:@(defaultValue) updatedBlock:^(NSObject* value) {
-        callback(@[[NSNull null], value]);
+        [self sendEvent:@"asyncVariable" withValue:@{@"id": _id, @"value": value}];
     }];
 }
 
-RCT_EXPORT_METHOD(_newAsyncString:(NSString *)name defaultValue:(NSString *)defaultValue callback:(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(_newAsyncString:(NSString *)name defaultValue:(NSString *)defaultValue callbackId:(nonnull NSNumber *)_id)
 {
     [TaplyticsVar taplyticsVarWithName:name defaultValue:defaultValue updatedBlock:^(NSObject* value) {
-        callback(@[[NSNull null], value]);
+        [self sendEvent:@"asyncVariable" withValue:@{@"id": _id, @"value": value}];
     }];
 }
 
-RCT_EXPORT_METHOD(_newAsyncNumber:(NSString *)name defaultValue:(nonnull NSNumber *)defaultValue callback:(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(_newAsyncNumber:(NSString *)name defaultValue:(nonnull NSNumber *)defaultValue callbackId:(nonnull NSNumber *)_id)
 {
     [TaplyticsVar taplyticsVarWithName:name defaultValue:defaultValue updatedBlock:^(NSObject* value) {
-        callback(@[[NSNull null], value]);
+        [self sendEvent:@"asyncVariable" withValue:@{@"id": _id, @"value": value}];
     }];
 }
 
-RCT_EXPORT_METHOD(_newAsyncObject:(NSString *)name defaultValue:(NSString *)defaultValue callback:(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(_newAsyncObject:(NSString *)name defaultValue:(NSString *)defaultValue callbackId:(nonnull NSNumber *)_id)
 {
     NSData* data = [defaultValue dataUsingEncoding:NSUTF8StringEncoding];
     NSError* err;
@@ -113,7 +113,7 @@ RCT_EXPORT_METHOD(_newAsyncObject:(NSString *)name defaultValue:(NSString *)defa
                     NSLog(@"%@", err.description);
                 }
                 NSString *stringifiedJSON = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-                callback(@[[NSNull null], stringifiedJSON]);
+                [self sendEvent:@"asyncVariable" withValue:@{@"id": _id, @"value": value}];
             }
         }];
     } @catch (NSException* e) {


### PR DESCRIPTION
Fixes the issue where using async variables on iOS SDK 3.0.0+ crashes the app from multiple invocations of the same promise.