### PR TITLE
Fix JCenter not able to download taplytics-react-native

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'com.android.library'
 
 buildscript {
     repositories {
-        jcenter()
+        // https://blog.gradle.org/jcenter-shutdown
+        mavenCentral()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.2'


### PR DESCRIPTION
## Description

Android builds failing due to some libraries that we have as dependencies still pointing to JCenter.  which was blocking our builds from succeded since JCenter is down. [Check this blog post](https://blog.gradle.org/jcenter-shutdown) to know more about it.

The error we are getting:
```
> Could not resolve all files for configuration ':taplytics-react-native:classpath'.
   > Could not resolve com.android.tools.build:bundletool:0.9.0.
     Required by:
         project :taplytics-react-native > com.android.tools.build:gradle:3.5.2
      > Could not resolve com.android.tools.build:bundletool:0.9.0.
         > Could not get resource 'https://jcenter.bintray.com/com/android/tools/build/bundletool/0.9.0/bundletool-0.9.0.pom'.
            > Could not HEAD 'https://jcenter.bintray.com/com/android/tools/build/bundletool/0.9.0/bundletool-0.9.0.pom'.
               > Read timed out
```

I also have forked on my own and tried the changes myself, the error goes away with my changes.

Now it works perfectly:
```
> Configure project :taplytics-react-native
Disable pre dexing for module taplytics-react-native
WARNING:DSL element 'dexOptions' is obsolete and should be removed.
It will be removed in version 8.0 of the Android Gradle plugin.
Using it has no effect, and the AndroidGradle plugin optimizes dexing automatically
```

## Notable Changes

Point to MavenCentral.


