### PR TITLE
fix: stop using deprecated removeEventListener method on provider

### DIFF
--- a/src/TaplyticsProvider/TaplyticsProvider.hooks.ts
+++ b/src/TaplyticsProvider/TaplyticsProvider.hooks.ts
@@ -96,10 +96,10 @@ export const useAppStateListener = ({ setError, setIsLoading, setRunningFeatureF
   }
 
   useEffect(() => {
-    AppState.addEventListener('change', handleAppStateChange)
+    let listener = AppState.addEventListener('change', handleAppStateChange);
 
     return () => {
-      AppState.removeEventListener('change', handleAppStateChange)
+      listener.remove();
     }
   }, [])
 }


### PR DESCRIPTION
## Description

Use the recommended `remove()` method, as the `removeEventListener` has been [deprecated](https://reactnative.dev/docs/appstate#removeeventlistener) by react native

## Notable Changes

<!-- Provide a little context into the notable files changed, and what changes were made to them. -->

The only change is on src/TaplyticsProvider/TaplyticsProvider.hooks.ts, where the app would crash on react-native 70. On React-native 67 the file will still work as expected. With this change the file will now work in both of the versions I tested (67 and 70)

## PR Checklist

- [ ] PR title follows the format of `[JIRA-TICKET-NUMBER/Ad-hoc]: [Short of PR]`
  - Example:
    - _TAP-1234: Added GitHub templates_
    - _Ad-hoc: Fixed linter command_
- **Testing - New feature**
  - [ ] N/A
  - **OR**
  - [ ] Make sure you've added a new test to the [test-repo](https://github.com/taplytics/taplytics-react-native-integration-tests) if existing tests do not effectively test the code changed. Also ensure that the tests are captured within the [Testing Strategy Doc](https://www.notion.so/taplytics/React-Native-SDK-Testing-Strategy-9c38a9d98b9d4ca788576a5dfbe7dcd7#370ffefe7e8341a98135c16c6de066a5).
