### PR TITLE
chore: update react native types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@commitlint/config-conventional": "^12.1.1",
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/react": "^17.0.3",
-    "@types/react-native": "^0.63.51",
+    "@types/react-native": "^0.65.1",
     "husky": "=4",
     "lint-staged": ">=10",
     "prettier": "2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1064,14 +1064,23 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/react-native@^0.63.51":
-  version "0.63.52"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.52.tgz#449beb4a413ec0f2c172cbf676a95f5b0952adf4"
-  integrity sha512-sBXvvtJaIUSXQLDh9NZitx1KHkKUdBLZy34lFKJaIXtpHIh5OEbBXeyUTFBtFwjk/RD0tneAtUqsdhheZRzAzw==
+"@types/react-native@^0.65.1":
+  version "0.65.31"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.65.31.tgz#b75d64144ce1b47b9ae7556c3b15fd1d504517d4"
+  integrity sha512-3hc6910BWlse/IQxeG2uvV76n2TMfbrcyAMIuXf2u3ICKd5f6X7Sjhh2Oi7orsZWGW3+y9pSac/dM6BUPuORtA==
   dependencies:
-    "@types/react" "*"
+    "@types/react" "^17"
 
-"@types/react@*", "@types/react@^17.0.3":
+"@types/react@^17":
+  version "17.0.62"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.62.tgz#2efe8ddf8533500ec44b1334dd1a97caa2f860e3"
+  integrity sha512-eANCyz9DG8p/Vdhr0ZKST8JV12PhH2ACCDYlFw6DIO+D+ca+uP4jtEDEpVqXZrh/uZdXQGwk7whJa3ah5DtyLw==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^17.0.3":
   version "17.0.3"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
   integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==


### PR DESCRIPTION
## Description

Fix error not being able to use `remove` as the return type of `addEventListener` is `void` by updating types package.

## Notable Changes

<!-- Provide a little context into the notable files changed, and what changes were made to them. -->

## PR Checklist

- [ ] PR title follows the format of `[JIRA-TICKET-NUMBER/Ad-hoc]: [Short of PR]`
  - Example:
    - _TAP-1234: Added GitHub templates_
    - _Ad-hoc: Fixed linter command_
- **Testing - New feature**
  - [ ] N/A
  - **OR**
  - [ ] Make sure you've added a new test to the [test-repo](https://github.com/taplytics/taplytics-react-native-integration-tests) if existing tests do not effectively test the code changed. Also ensure that the tests are captured within the [Testing Strategy Doc](https://www.notion.so/taplytics/React-Native-SDK-Testing-Strategy-9c38a9d98b9d4ca788576a5dfbe7dcd7#370ffefe7e8341a98135c16c6de066a5).
